### PR TITLE
Remove website from metadata

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -4,7 +4,6 @@ description = "A MIME types library for Gleam"
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "lpil", repo = "marceau" }
 links = [
-  { title = "Website", href = "https://gleam.run" },
   { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
 ]
 


### PR DESCRIPTION
This website is the home of the Gleam project, not of this project.