### PR TITLE
Run `gleam format` to fix CI failure

### DIFF
--- a/test/marceau_test.gleam
+++ b/test/marceau_test.gleam
@@ -1,5 +1,5 @@
-import gleam/list
 import gleam/io
+import gleam/list
 import gleeunit
 import marceau
 


### PR DESCRIPTION
[CI is failing][0] because `gleam format` had not been run on a test file. This fixes that.

[0]: https://github.com/lpil/marceau/actions/runs/11295476828/job/31418268604